### PR TITLE
create play recode functions and targets; fix #67

### DIFF
--- a/R/recode_play.R
+++ b/R/recode_play.R
@@ -1,0 +1,43 @@
+################################################################################
+#
+#'
+#' Recode child play indicators
+#'
+#
+################################################################################
+
+play_recode_response <- function(x, na_values) {
+  ifelse(
+    x %in% na_values, NA,
+    ifelse(x == 2, 0, 1)
+  )
+}
+
+
+play_recode_responses <- function(vars, .data, na_values) {
+  x <- .data[vars]
+  
+  apply(
+    X = x,
+    MARGIN = 2,
+    FUN = play_recode_response,
+    na_values = c(8, 9),
+    simplify = TRUE
+  ) |>
+    data.frame() |>
+    (\(x) { names(x) <- vars; x } )()
+}
+
+
+play_recode <- function(vars, .data, na_values) {
+  core_vars <- get_core_variables(raw_data_clean = .data)
+  
+  recoded_vars <- play_recode_responses(
+    vars = vars,
+    .data = .data,
+    na_values = na_values
+  )
+  
+  data.frame(core_vars, recoded_vars)
+}
+

--- a/_targets.R
+++ b/_targets.R
@@ -630,7 +630,13 @@ data_processed <- tar_plan(
     label = rep(list(NULL), length(vars))
   ),
   ## Time-to-travel
-  travel_recode_data = travel_recode(raw_data_clean)
+  travel_recode_data = travel_recode(raw_data_clean),
+  ## Play
+  play_recode_data = play_recode(
+    vars = paste0("play", c(paste0(1, letters[1:7]), 2, paste0(3, letters[1:6]))),
+    .data = raw_data_clean,
+    na_values = c(8, 9)
+  )
 )
 
 


### PR DESCRIPTION
fix #67 

```
################################################################################
#
#'
#' Recode child play indicators
#'
#
################################################################################

play_recode_response <- function(x, na_values) {
  ifelse(
    x %in% na_values, NA,
    ifelse(x == 2, 0, 1)
  )
}
```

```
play_recode_responses <- function(vars, .data, na_values) {
  x <- .data[vars]
  
  apply(
    X = x,
    MARGIN = 2,
    FUN = play_recode_response,
    na_values = c(8, 9),
    simplify = TRUE
  ) |>
    data.frame() |>
    (\(x) { names(x) <- vars; x } )()
}
```

```
play_recode <- function(vars, .data, na_values) {
  core_vars <- get_core_variables(raw_data_clean = .data)
  
  recoded_vars <- play_recode_responses(
    vars = vars,
    .data = .data,
    na_values = na_values
  )
  
  data.frame(core_vars, recoded_vars)
}
```
